### PR TITLE
Fix layout issues in dashboard UI

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -22,7 +22,7 @@ const AppContent = () => {
   return (
     <div className="min-h-screen bg-background text-text-primary flex flex-col font-sans">
       <Header />
-      <div className="flex-grow w-full max-w-viewport mx-auto grid grid-cols-12 gap-8 px-8">
+      <div className="flex-grow w-full max-w-viewport mx-auto grid grid-cols-12 gap-8 px-4 sm:px-8">
         
         {/* Left Rail PDF Viewer */}
         <AnimatePresence>

--- a/apps/dashboard/src/components/audit-panel.tsx
+++ b/apps/dashboard/src/components/audit-panel.tsx
@@ -95,7 +95,7 @@ const AuditPanel: React.FC<{ logs: PipelineLogEntry[] }> = ({ logs }) => {
         ) : (
           <List
             ref={listRef}
-            height={800} // This should be dynamic based on parent
+            height={600}
             itemCount={logs.length}
             itemSize={60} // Average item height. Items can be expanded.
             width="100%"

--- a/apps/dashboard/src/components/document-selection-panel.tsx
+++ b/apps/dashboard/src/components/document-selection-panel.tsx
@@ -12,7 +12,7 @@ interface DocumentSelectionPanelProps {
 
 export const DocumentSelectionPanel: React.FC<DocumentSelectionPanelProps> = ({ dispatch }) => {
   return (
-    <div className="flex flex-col min-h-full">
+    <div className="flex flex-col min-h-screen px-4 space-y-8">
       <IntroHeader activeFramework={null} dispatch={dispatch} />
       <div className="flex-grow text-center py-16">
         <h2 className="text-2xl font-semibold text-text-primary tracking-tight">Select a Constraint Framework</h2>

--- a/apps/dashboard/src/components/footer.tsx
+++ b/apps/dashboard/src/components/footer.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const Footer: React.FC = () => {
   return (
     <footer className="w-full border-t border-ui-primary mt-16">
-      <div className="max-w-viewport mx-auto px-8 py-6">
+      <div className="max-w-viewport mx-auto px-4 sm:px-8 py-6">
         <p className="text-center text-sm text-text-tertiary">
           This system's architecture is a foundation for constitutional-scale reasoning, capable of encoding auditable, legally aligned generative logic
           <br />

--- a/apps/dashboard/src/components/framework-card.tsx
+++ b/apps/dashboard/src/components/framework-card.tsx
@@ -17,7 +17,7 @@ export const FrameworkCard: React.FC<FrameworkCardProps> = ({ framework, onSelec
   return (
     <motion.button
       onClick={onSelect}
-      className="bg-ui-primary rounded-lg border border-white/10 overflow-hidden text-left flex flex-col group focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
+      className="bg-ui-primary rounded-lg border border-white/10 overflow-hidden text-left flex flex-col h-full group focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan"
       whileHover={{ y: -5, boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)' }}
       transition={{ type: 'spring', stiffness: 300 }}
     >

--- a/apps/dashboard/src/components/header.tsx
+++ b/apps/dashboard/src/components/header.tsx
@@ -5,7 +5,7 @@ import { GithubIcon } from './icons';
 const Header: React.FC = () => {
   return (
     <header className="bg-background/80 backdrop-blur-sm border-b border-ui-primary sticky top-0 z-50">
-      <div className="max-w-viewport mx-auto px-8">
+      <div className="max-w-viewport mx-auto px-4 sm:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center space-x-4">
             <span className="text-lg font-semibold tracking-tight text-text-primary">

--- a/apps/dashboard/src/components/navigation-bar.tsx
+++ b/apps/dashboard/src/components/navigation-bar.tsx
@@ -16,7 +16,7 @@ const DOMAINS: { id: Domain; name: string }[] = [
 
 export const NavigationBar: React.FC<NavigationBarProps> = ({ activeDomain, onActiveDomainChange }) => {
     return (
-        <div className="border-b border-ui-primary flex items-center space-x-8" role="tablist">
+        <div className="border-b border-ui-primary flex flex-wrap items-center space-x-8 overflow-x-auto px-2" role="tablist">
             {DOMAINS.map(domain => {
                 const isSelected = activeDomain === domain.id;
                 return (

--- a/apps/dashboard/src/components/orchestration-input-panel.tsx
+++ b/apps/dashboard/src/components/orchestration-input-panel.tsx
@@ -29,7 +29,7 @@ export const OrchestrationInputPanel: React.FC<OrchestrationInputPanelProps> = (
                 disabled={isLoading}
                 aria-label="Prompt Input"
             />
-            <div className="flex items-center justify-end space-x-4">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
                  {error && <p className="text-red-400 text-sm text-center flex-1">{error}</p>}
                 <motion.button
                     type="submit"

--- a/apps/dashboard/src/components/pdf-viewer.tsx
+++ b/apps/dashboard/src/components/pdf-viewer.tsx
@@ -78,7 +78,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({ framework }) => {
                 ref={imageRef}
                 src={pagePath}
                 alt={`${framework.title} page ${currentPage}`}
-                className="max-w-none h-auto shadow-lg"
+                className="max-w-full h-auto shadow-lg"
                 style={{ scale: zoom }}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/apps/dashboard/src/components/wizard-indicator.tsx
+++ b/apps/dashboard/src/components/wizard-indicator.tsx
@@ -15,7 +15,7 @@ const steps = [
 
 export const WizardIndicator: React.FC<WizardIndicatorProps> = ({ currentStep }) => {
   return (
-    <div className="flex items-center justify-between w-full py-4">
+    <div className="flex flex-wrap items-center justify-between w-full gap-2 py-4">
       {steps.map((step, index) => {
         const stepNumber = index + 1;
         const isActive = currentStep === stepNumber;


### PR DESCRIPTION
## Summary
- tweak responsive padding for header, footer, and main grid
- ensure DocumentSelectionPanel fills the screen
- keep FrameworkCard heights consistent
- wrap button area in OrchestrationInputPanel for mobile
- allow NavigationBar to scroll horizontally
- make WizardIndicator wrap on small screens
- adjust AuditPanel height
- prevent PDF overflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b47422c94832fae895cc42da40331