### PR TITLE
Fix dev server port in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A modern, high-performance dashboard built with React, TypeScript, and Vite, fea
    npm run dev
    ```
    
-   The app will be available at `http://localhost:5173`
+   The app will be available at `http://localhost:3001`
 
 ### Available Scripts
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -38,7 +38,7 @@ A modern, high-performance dashboard built with React, TypeScript, and Vite, fea
    npm run dev
    ```
    
-   The app will be available at `http://localhost:5173`
+   The app will be available at `http://localhost:3001`
 
 ### Available Scripts
 


### PR DESCRIPTION
## Summary
- correct dev server port in `README.md` and `docs/readme.md`

## Testing
- `npm run test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_686b54f41684832fbf413695f714152e